### PR TITLE
Adding support for constructing absolute filepaths

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -50,7 +51,11 @@ func compare(args []string) {
 
 	if strings.HasPrefix(newCommit, "--local-path=")  {
 		parts := strings.Split(newCommit, "=")
-		schNew = loadLocalPackageSpec(parts[1])
+		schemaPath, err := filepath.Abs(parts[1])
+		if err != nil {
+			panic("unable to construct absolute path to schema.json")
+		}
+		schNew = loadLocalPackageSpec(schemaPath)
 	} else {
 		schemaUrlNew := fmt.Sprintf("https://raw.githubusercontent.com/pulumi/pulumi-%s/%s/provider/cmd/pulumi-resource-%[1]s/schema.json", provider, newCommit)
 		schNew = downloadSchema(schemaUrlNew)


### PR DESCRIPTION
```
▶ schema-tools compare gcp master --local-path=provider/cmd/pulumi-resource-gcp/schema.json
Found 2 breaking changes:
Resource "gcp:eventarc/trigger:Trigger" missing output "transports"
Type "gcp:eventarc/TriggerTransport:TriggerTransport" missing property "pubsubs"

New resources/functions:
gcp:kms/getKMSSecretAsymmetric:getKMSSecretAsymmetric
```

```
▶ schema-tools compare gcp master --local-path=/Users/stack72/code/go/src/github.com/pulumi/pulumi-gcp/provider/cmd/pulumi-resource-gcp/schema.json
Found 2 breaking changes:
Resource "gcp:eventarc/trigger:Trigger" missing output "transports"
Type "gcp:eventarc/TriggerTransport:TriggerTransport" missing property "pubsubs"

New resources/functions:
gcp:kms/getKMSSecretAsymmetric:getKMSSecretAsymmetric
```