### PR TITLE
Fix panic when all arguments are dropped from a function.

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,6 +194,11 @@ func compare(args []string) {
 		}
 
 		for propName, prop := range f.Inputs.Properties {
+			if newFunc.Inputs == nil {
+				violations = append(violations, fmt.Sprintf("Function %q missing input %q", funcName, propName))
+				continue
+			}
+
 			newProp, ok := newFunc.Inputs.Properties[propName]
 			if !ok {
 				violations = append(violations, fmt.Sprintf("Function %q missing input %q", funcName, propName))


### PR DESCRIPTION
To test:

```bash
go build && ./schema-tools compare -p auth0 -n afaf824a9890
```

Will panic on `master`, will not panic on this branch.