### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 on:
   push:
-    tags: [ "v*.[0-99]" ] # only a valid semver tag
-
+    tags:
+    - v*.*.*
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use `v*.*.*` for semver trigger.

It appears the latest tag did not actually trigger the release workflow. This will cause all CI in providers to fail.